### PR TITLE
Event object is duplicated in arguments passed to listener whe…

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -126,8 +126,7 @@ export default Ember.Service.extend({
       }
 
       // Push the event object onto arguments
-      const args = options.arguments || [];
-      args.unshift(e);
+      const args = [e].concat(options.arguments || []);
 
       // Use run loop if debounce, throttle or scheduleOnce is specified
       // else call callback immediately


### PR DESCRIPTION
This PR resolves the issue reported in #5. When an options.arguments is specified, each time the event handler runs, it adds an additional copy of the event to the first of the arguments passed to the key listener. This is because the code inadvertently updates the options.arguments in the process of adding the event as the first argument.
