### PR TITLE
Issue 6: Key listeners with modifier keys called even when no modifier pressed.

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -101,7 +101,10 @@ export default Ember.Service.extend({
         return;
       }
 
-      // Check modifier key requirements
+      // Check modifier key requirements.
+      // Disable jshint warning of "confusing use of !". The idiom is
+      // "a_boolean === !b_boolean_or_undefined". !== is not equivalent.
+      // jshint -W018
       if (isMacOs() && options.useCmdOnMac) {
         if (e.metaKey === !options.requireCtrl) { return; }
       } else {
@@ -111,6 +114,7 @@ export default Ember.Service.extend({
 
       if (e.altKey === !options.requireAlt)   { return; }
       if (e.shiftKey === !options.requireShift) { return; }
+      // jshint +W018
 
       let fn = callback;
 

--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -102,16 +102,15 @@ export default Ember.Service.extend({
       }
 
       // Check modifier key requirements
-      if (options.requireCtrl && options.useCmdOnMac && isMacOs()) {
-        if (!e.metaKey) { return; }
+      if (isMacOs() && options.useCmdOnMac) {
+        if (e.metaKey === !options.requireCtrl) { return; }
       } else {
-        if (e.ctrlKey  && !options.requireCtrl ) { return; }
-        if (e.metaKey  && !options.requireMeta ) { return; }
+        if (e.ctrlKey === !options.requireCtrl ) { return; }
+        if (e.metaKey === !options.requireMeta ) { return; }
       }
 
-      if (e.altKey   && !options.requireAlt)   { return; }
-      if (e.shiftKey && !options.requireShift) { return; }
-
+      if (e.altKey === !options.requireAlt)   { return; }
+      if (e.shiftKey === !options.requireShift) { return; }
 
       let fn = callback;
 


### PR DESCRIPTION
See #6. If you create a handler for, say, `ctrl+x`, it will be called even if ctrl is not pressed.
