### PR TITLE
Use KEYCODE_TO_KEY_MAP[keyCode] in preference to key.

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -88,7 +88,7 @@ export default Ember.Service.extend({
   },
 
   _handleKeyPress(e) {
-    let key = e.key || KEYCODE_TO_KEY_MAP[e.keyCode];
+    let key = KEYCODE_TO_KEY_MAP[e.keyCode] || e.key;
     const listeners = this._listenersForKey(key);
 
     if (key === '.') {


### PR DESCRIPTION
In processing they defined keys, I think it would be preferable to use the event's keyCode to the key. For example, a definition of `ctrl+shift-x` will not match a keystroke of control plus shift plus x. Instead, it would have to be defined as `ctrl+shift-X`. This patch addresses that. It would be a breaking change for anyone with shortcuts defined with `shift+...`
