### PR TITLE
Support contenteditable attribute as being "input like".

### DIFF
--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -101,7 +101,10 @@ export default Ember.Service.extend({
         return;
       }
 
-      // Check modifier key requirements
+      // Check modifier key requirements.
+      // Disable jshint warning of "confusing use of !". The idiom is
+      // "a_boolean === !b_boolean_or_undefined". !== is not equivalent.
+      // jshint -W018
       if (isMacOs() && options.useCmdOnMac) {
         if (e.metaKey === !options.requireCtrl) { return; }
       } else {
@@ -111,6 +114,7 @@ export default Ember.Service.extend({
 
       if (e.altKey === !options.requireAlt)   { return; }
       if (e.shiftKey === !options.requireShift) { return; }
+      // jshint +W018
 
       let fn = callback;
 

--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -9,7 +9,7 @@ const { debounce, once, throttle } = Ember.run;
 const rMacOs = /Mac OS X/;
 
 function elementIsInputLike(element) {
-  return ['INPUT', 'TEXTAREA'].indexOf(element.tagName) !== -1;
+  return ['INPUT', 'TEXTAREA'].indexOf(element.tagName) !== -1 || Ember.$(element).closest('[contenteditable]').is('[contenteditable="true"]');
 }
 
 function optionsAreEqual(optionsA, optionsB) {

--- a/addon/services/keyboard.js
+++ b/addon/services/keyboard.js
@@ -102,16 +102,15 @@ export default Ember.Service.extend({
       }
 
       // Check modifier key requirements
-      if (options.requireCtrl && options.useCmdOnMac && isMacOs()) {
-        if (!e.metaKey) { return; }
+      if (isMacOs() && options.useCmdOnMac) {
+        if (e.metaKey === !options.requireCtrl) { return; }
       } else {
-        if (e.ctrlKey  && !options.requireCtrl ) { return; }
-        if (e.metaKey  && !options.requireMeta ) { return; }
+        if (e.ctrlKey === !options.requireCtrl ) { return; }
+        if (e.metaKey === !options.requireMeta ) { return; }
       }
 
-      if (e.altKey   && !options.requireAlt)   { return; }
-      if (e.shiftKey && !options.requireShift) { return; }
-
+      if (e.altKey === !options.requireAlt)   { return; }
+      if (e.shiftKey === !options.requireShift) { return; }
 
       let fn = callback;
 


### PR DESCRIPTION
Currently only input and textarea elements are considered "input like" for the purpose of suppressing keystroke commands. HTML5 supports the contenteditable attribute, which is, well, like an input element. This patch adds support for the element or one of its parent being contenteditable.
